### PR TITLE
Display homepage and access request buttons

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
         "github": "https://github.com/Public-nEUro/"
     },
     "dataset_options": {
-        "include_datalad": true,
+        "include_datalad": false,
         "include_github": false,
         "include_gitlab": false,
         "include_gin": false,

--- a/metadata/PN000001/V1/f96/4b9b89733ccf41026b46c70631f4a.json
+++ b/metadata/PN000001/V1/f96/4b9b89733ccf41026b46c70631f4a.json
@@ -1,1 +1,230 @@
-{"type": "dataset", "dataset_id": "PN000001", "dataset_version": "V1", "children": [{"type": "file", "dataset_id": "PN000001", "dataset_version": "V1", "path": "dataset_description.json", "contentbytesize": 383, "metadata_sources": {"sources": [{"source_name": "OpenNeuro_PET", "source_version": "V1", "agent_name": "Cyril Pernet"}]}, "name": "dataset_description.json"}, {"type": "directory", "name": "sourcedata", "path": "sourcedata", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-CanonCartesionPrimeNIA", "path": "sub-CanonCartesionPrimeNIA", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricAdvanceJHU", "path": "sub-GeneralElectricAdvanceJHU", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricAdvanceLongNIMH", "path": "sub-GeneralElectricAdvanceLongNIMH", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricAdvanceNIMH", "path": "sub-GeneralElectricAdvanceNIMH", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricDiscoveryAarhus", "path": "sub-GeneralElectricDiscoveryAarhus", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricSignaAarhus", "path": "sub-GeneralElectricSignaAarhus", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-GeneralElectricSignaNIMH", "path": "sub-GeneralElectricSignaNIMH", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-PhilipsGeminiUnimedizinMainz", "path": "sub-PhilipsGeminiUnimedizinMainz", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-PhilipsIngenuityPETCTAmsterdamUMC", "path": "sub-PhilipsIngenuityPETCTAmsterdamUMC", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-PhilipsIngenuityPETMRAmsterdamUMC", "path": "sub-PhilipsIngenuityPETMRAmsterdamUMC", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-PhillipsVereosAmsterdamUMC", "path": "sub-PhillipsVereosAmsterdamUMC", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-SiemensBiographNIMH", "path": "sub-SiemensBiographNIMH", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-SiemensBiographNRU", "path": "sub-SiemensBiographNRU", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-SiemensHRRTJHU", "path": "sub-SiemensHRRTJHU", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-SiemensHRRTNRU", "path": "sub-SiemensHRRTNRU", "dataset_id": "PN000001", "dataset_version": "V1"}, {"type": "directory", "name": "sub-SiemensTrioBrainPETFZJ", "path": "sub-SiemensTrioBrainPETFZJ", "dataset_id": "PN000001", "dataset_version": "V1"}], "metadata_sources": {"key_source_map": {"name": ["OpenNeuroPET"], "description": ["OpenNeuroPET"], "url": ["OpenNeuroPET"], "keywords": ["OpenNeuroPET"], "license": ["OpenNeuroPET"], "authors": ["OpenNeuroPET"]}, "sources": [{"source_name": "OpenNeuroPET", "source_version": "1", "agent_name": "Cyril Pernet"}]}, "name": "OpenNeuroPET Phantoms", "description": "The PET Brain phantoms dataset is curated by OpenNeuroPET. This repository contains source data from PET scanners that need to be converted to nifti format, preferably following BIDS. An issue with ecat and DICOM data is that many tags are not mandatory and many values are not standardized making it difficult to harmonize the outputs of conversion, in particular side car json files. Here we collected many phantoms from different sites and scanners allowing to check the different header tags and values. This also allows validated conversion tools. Such test is performed via the code folder where one use the PET2BIDS library to do the conversion (which depends on dcm2niix for DICOM). Feel free to contact OpenNeuroPET to add your data from a scanner we have not tested.", "url": "https://computerome.dk/shared-files/gAAAAABmVvyHY1U1UIbfCS7tCkFPO-kx7G-gK4KjTuSxrjQeoa7jaoW5LXb_NJiOtXAnWLz6IhJVCeRqWwHRHFxmhh3iR9s1OMX4MAEU7BxzAD_CBwwuX-pAwA7G7Y2HPUdTE6fPQNM0ERimIfBEop_JThZ3gBF4G2fWpz_yKVO5OYE7DZyjU_OO2xQRZRXClAUYkdWY5aq8M5n8MtO_X9AzHeImP9NAos_vuml6NTWIDEyXlDVIytfgEhEj-6l0ozuFU584alDEyJ7wfyvxOmvwG_TiuY6Ylw%3D%3D", "keywords": ["dcm2niix", "PET2BIDS", "Source files", "Brain", "ecat7", "Conversion", "Positron Emission Tomography", "PET", "Phantom", "DICOM"], "license": {"name": "CC BY 4.0", "url": "https://creativecommons.org/licenses/by/4.0/"}, "authors": [{"givenName": "S\u00f8ren", "familyName": "Baarsgaard Hansen"}, {"givenName": "Murat ", "familyName": "Bilgel"}, {"givenName": "Keith ", "familyName": "Ciantar"}, {"givenName": "Anthony ", "familyName": "Galassi"}, {"givenName": "Gabriel", "familyName": "Gonzalez-Escamilla"}, {"givenName": "Sune", "familyName": "H\u00f8gild Kelle"}, {"givenName": "Cyril", "familyName": "Pernet"}, {"givenName": "Maqsood", "familyName": "Yaqub"}]}
+{
+    "type": "dataset",
+    "dataset_id": "PN000001",
+    "dataset_version": "V1",
+    "children": [
+        {
+            "type": "file",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1",
+            "path": "dataset_description.json",
+            "contentbytesize": 383,
+            "metadata_sources": {
+                "sources": [
+                    {
+                        "source_name": "OpenNeuro_PET",
+                        "source_version": "V1",
+                        "agent_name": "Cyril Pernet"
+                    }
+                ]
+            },
+            "name": "dataset_description.json"
+        },
+        {
+            "type": "directory",
+            "name": "sourcedata",
+            "path": "sourcedata",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-CanonCartesionPrimeNIA",
+            "path": "sub-CanonCartesionPrimeNIA",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricAdvanceJHU",
+            "path": "sub-GeneralElectricAdvanceJHU",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricAdvanceLongNIMH",
+            "path": "sub-GeneralElectricAdvanceLongNIMH",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricAdvanceNIMH",
+            "path": "sub-GeneralElectricAdvanceNIMH",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricDiscoveryAarhus",
+            "path": "sub-GeneralElectricDiscoveryAarhus",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricSignaAarhus",
+            "path": "sub-GeneralElectricSignaAarhus",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-GeneralElectricSignaNIMH",
+            "path": "sub-GeneralElectricSignaNIMH",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-PhilipsGeminiUnimedizinMainz",
+            "path": "sub-PhilipsGeminiUnimedizinMainz",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-PhilipsIngenuityPETCTAmsterdamUMC",
+            "path": "sub-PhilipsIngenuityPETCTAmsterdamUMC",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-PhilipsIngenuityPETMRAmsterdamUMC",
+            "path": "sub-PhilipsIngenuityPETMRAmsterdamUMC",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-PhillipsVereosAmsterdamUMC",
+            "path": "sub-PhillipsVereosAmsterdamUMC",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-SiemensBiographNIMH",
+            "path": "sub-SiemensBiographNIMH",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-SiemensBiographNRU",
+            "path": "sub-SiemensBiographNRU",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-SiemensHRRTJHU",
+            "path": "sub-SiemensHRRTJHU",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-SiemensHRRTNRU",
+            "path": "sub-SiemensHRRTNRU",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        },
+        {
+            "type": "directory",
+            "name": "sub-SiemensTrioBrainPETFZJ",
+            "path": "sub-SiemensTrioBrainPETFZJ",
+            "dataset_id": "PN000001",
+            "dataset_version": "V1"
+        }
+    ],
+    "metadata_sources": {
+        "key_source_map": {
+            "name": [
+                "OpenNeuroPET"
+            ],
+            "description": [
+                "OpenNeuroPET"
+            ],
+            "url": [
+                "OpenNeuroPET"
+            ],
+            "keywords": [
+                "OpenNeuroPET"
+            ],
+            "license": [
+                "OpenNeuroPET"
+            ],
+            "authors": [
+                "OpenNeuroPET"
+            ]
+        },
+        "sources": [
+            {
+                "source_name": "OpenNeuroPET",
+                "source_version": "1",
+                "agent_name": "Cyril Pernet"
+            }
+        ]
+    },
+    "name": "OpenNeuroPET Phantoms",
+    "description": "The PET Brain phantoms dataset is curated by OpenNeuroPET. This repository contains source data from PET scanners that need to be converted to nifti format, preferably following BIDS. An issue with ecat and DICOM data is that many tags are not mandatory and many values are not standardized making it difficult to harmonize the outputs of conversion, in particular side car json files. Here we collected many phantoms from different sites and scanners allowing to check the different header tags and values. This also allows validated conversion tools. Such test is performed via the code folder where one use the PET2BIDS library to do the conversion (which depends on dcm2niix for DICOM). Feel free to contact OpenNeuroPET to add your data from a scanner we have not tested.",
+    "homepage_url": "https://computerome.dk/shared-files/gAAAAABmVvyHY1U1UIbfCS7tCkFPO-kx7G-gK4KjTuSxrjQeoa7jaoW5LXb_NJiOtXAnWLz6IhJVCeRqWwHRHFxmhh3iR9s1OMX4MAEU7BxzAD_CBwwuX-pAwA7G7Y2HPUdTE6fPQNM0ERimIfBEop_JThZ3gBF4G2fWpz_yKVO5OYE7DZyjU_OO2xQRZRXClAUYkdWY5aq8M5n8MtO_X9AzHeImP9NAos_vuml6NTWIDEyXlDVIytfgEhEj-6l0ozuFU584alDEyJ7wfyvxOmvwG_TiuY6Ylw%3D%3D",
+    "access_request_contact": {
+        "givenName": "Cyril",
+        "familyName": "Pernet",
+        "email": "cyril.pernet@nru.dk"
+    },
+    "keywords": [
+        "dcm2niix",
+        "PET2BIDS",
+        "Source files",
+        "Brain",
+        "ecat7",
+        "Conversion",
+        "Positron Emission Tomography",
+        "PET",
+        "Phantom",
+        "DICOM"
+    ],
+    "license": {
+        "name": "CC BY 4.0",
+        "url": "https://creativecommons.org/licenses/by/4.0/"
+    },
+    "authors": [
+        {
+            "givenName": "S\u00f8ren",
+            "familyName": "Baarsgaard Hansen"
+        },
+        {
+            "givenName": "Murat ",
+            "familyName": "Bilgel"
+        },
+        {
+            "givenName": "Keith ",
+            "familyName": "Ciantar"
+        },
+        {
+            "givenName": "Anthony ",
+            "familyName": "Galassi"
+        },
+        {
+            "givenName": "Gabriel",
+            "familyName": "Gonzalez-Escamilla"
+        },
+        {
+            "givenName": "Sune",
+            "familyName": "H\u00f8gild Kelle"
+        },
+        {
+            "givenName": "Cyril",
+            "familyName": "Pernet"
+        },
+        {
+            "givenName": "Maqsood",
+            "familyName": "Yaqub"
+        }
+    ]
+}


### PR DESCRIPTION
- adds the 'access_request_contact' key and value to the metadata record, which is necessary in order to show the related button
- changes the 'url' key to 'homepage_url' key since the existing url is not a datalad dataset url and links to the dataset homepage
- sets the 'include_datalad' flag to false in the catalog-level config in order to make sure the datalad download button is hidden

Screenshot:

<img width="1369" alt="Screenshot 2024-06-25 at 09 53 51" src="https://github.com/Public-nEUro/DataCatalogue/assets/10141237/15fa3697-0f2f-4fbf-bb6b-a89a18af43d6">
